### PR TITLE
Auto pause feature when computer is locked or idle

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -342,6 +342,18 @@
   "setting_syncSettings": {
     "message": "Einstellungen mit Chrome sync synchronisieren"
   },
+  "setting_pauseOnLock": {
+    "message": "Pause für Musik, wenn der Computer gesperrt ist"
+  },
+  "setting_pauseOnLockHint": {
+    "message": "Diese Option Pausen Musik, wenn Sie Ihren Computer sperren"
+  },
+  "setting_pauseOnIdle": {
+    "message": "Pause für Musik, wenn Computer im Leerlauf 60 Sekunden"
+  },
+  "setting_pauseOnIdleHint": {
+    "message": "Diese Option Pausen Musik, wenn Ihr Computer im Leerlauf 60 Sekunden"
+  },
   "setting_preventCommandRatingReset": {
     "message": "Setze Bewertungen niemals zur\u00FCck, die nicht sichtbar sind"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -456,6 +456,22 @@
     "message": "Sync settings with Chrome sync",
     "description": "label for option to sync settings"
   },
+  "setting_pauseOnLock": {
+    "message": "Pause music when computer is locked",
+    "description": "label for option to pause on lock"
+  },
+  "setting_pauseOnLockHint": {
+    "message": "This option pauses music when you lock your computer and resumes it on unlock",
+    "description": "hint for option to pause on lock"
+  },
+  "setting_pauseOnIdle": {
+    "message": "Pause music when computer is idle for 60s",
+    "description": "label for option to pause on idle"
+  },
+  "setting_pauseOnIdleHint": {
+    "message": "This option pauses music when your computer is idle for 60s and resumes it on any action",
+    "description": "hint for option to pause on lock"
+  },
   "setting_preventCommandRatingReset": {
     "message": "Prevent rating resets without feedback",
     "description": "label for option to prevent rating resets"

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -651,6 +651,10 @@ chrome.runtime.getBackgroundPage(function(bp) {
     initHint("preventCommandRatingReset");
     initCheckbox("updateNotifier");
     initCheckbox("syncSettings", localSettings);
+    initCheckbox("pauseOnLock");
+    initHint("pauseOnLock");
+    initCheckbox("pauseOnIdle");
+    initHint("pauseOnIdle");
     initCheckbox("gaEnabled");
     initHint("gaEnabled");
     

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,7 +16,8 @@
     "*://play.google.com/music/listen*",
     "notifications",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "idle"
   ],
   "optional_permissions": [ "http://www.songlyrics.com/*", "http://lyrics.wikia.com/*", "https://www.musixmatch.com/*" ],
   "browser_action": {

--- a/src/options.html
+++ b/src/options.html
@@ -146,6 +146,8 @@
       <div class="v-2.7.1 exp" id="preventCommandRatingReset"></div>
       <div class="v-1.1 adv" id="updateNotifier"></div>
       <div class="v-1.4 adv" id="syncSettings"></div>
+      <div class="exp" id="pauseOnLock"></div>
+      <div class="exp" id="pauseOnIdle"></div>
       <div class="exp" id="gaEnabled"></div>
     </fieldset>
     <button id="resetSettings"></button>


### PR DESCRIPTION
This feature automatically pauses music when computer becomes idle for 60s, is locked or both and resumes when computer becomes active again.

It uses [`chrome.idle`](https://developer.chrome.com/apps/idle) API.

![feature](https://cloud.githubusercontent.com/assets/1055370/6358828/291ed230-bc77-11e4-8efd-bd03523c8913.png)