### PR TITLE
Add option to show a confirmation dialogue when closing the tab while music is playing

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -284,6 +284,9 @@
   "setting_gaEnabledHint": {
     "message": "Es werden keine persönlichen Daten (z.B. gespielte Songs) gesammelt. Die Daten dienen nur zur Analyse häufig genutzer Funktionen und Einstellungen."
   },
+  "setting_confirmClose": {
+    "message": "Während der Wiedergabe vor dem Schliessen des Google Music Tabs nachfragen."
+  },
   "scrobblePosition": {
     "message": "Hier wird gescrobbelt"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -379,6 +379,10 @@
     "message": "No personal data (e.g. played songs) will be collected. This is only to analyse commonly used features and settings.",
     "description": "hint for option to enable Google Analytics"
   },
+  "setting_confirmClose": {
+    "message": "Show a confirmation dialogue before closing the Google Music tab when music is playing.",
+    "description": "label for option to show a confirmation dialogue on close"
+  },
   "scrobblePosition": {
     "message": "Here will be scrobbled",
     "description": "tooltip for scrobble position indicator in miniplayer"

--- a/src/js/bp.js
+++ b/src/js/bp.js
@@ -190,6 +190,7 @@ function fixForUri(string) {
     autoRestoreGm: true,
     updateNotifier: true,
     gaEnabled: true,
+    confirmClose: false,
     //}
     //{ filter
     optionsMode: "beg",
@@ -1408,6 +1409,11 @@ function fixForUri(string) {
   function closeGm() {
     if (googlemusictabId) chromeTabs.remove(googlemusictabId);
   }
+
+  /** Enable or disable the confirmation dialogue when closing the tab while music is playing */
+  function setConfirmClose(val) {
+    executeInGoogleMusic("setConfirmClose", { confirmClose: val });
+  }
   //} Google tab handling
 
   //{ miniplayer handling
@@ -1975,6 +1981,12 @@ function fixForUri(string) {
   //} idle/locked handling
 
   //{ register general listeners
+  settings.w("confirmClose", function(val) {
+    if (!val) {
+      setConfirmClose(false);
+    }
+    player.wrl("playing", setConfirmClose, val);
+  });
   settings.w("iconClickAction0 iconClickConnectAction", iconClickSettingsChanged);
   settings.w("miniplayerType", function() {
     if (miniplayer) openMiniplayer();//reopen

--- a/src/js/injected.js
+++ b/src/js/injected.js
@@ -7,6 +7,8 @@
  * @license BSD license
  */
 (function() {
+  var confirmClose = false;
+
   /**
    * Simulate a mouse event.
    * @param eventname type of event
@@ -253,9 +255,17 @@
     case "cleanup":
       cleanup();
       break;
+    case "setConfirmClose":
+      confirmClose = event.data.options.confirmClose;
+      break;
     }
   }
 
   window.addEventListener("message", onMessage);
+  window.onbeforeunload = function() {
+    if (confirmClose) {
+      return "Google Music is currently playing.";
+    }
+  };
   console.info("Prime Player extension connected.");
 })();

--- a/src/options.html
+++ b/src/options.html
@@ -141,6 +141,7 @@
       <div class="v-1.1 adv i-c" id="updateNotifier"></div>
       <div class="v-1.4 adv local i-c i-h" id="syncSettings"></div>
       <div class="exp i-c i-h" id="gaEnabled"></div>
+      <div class="adv i-c" id="confirmClose"></div>
     </fieldset>
     <button id="resetSettings"></button>
   </div>


### PR DESCRIPTION
This pull request adds an option to Prime Player to show a confirmation dialogue when closing the Google Music tab while music is playing. This is to prevent Google Music from being accidentally closed. 